### PR TITLE
ci: change default bucket region in automated creation

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -23,6 +23,7 @@ frameworkVersion: '2'
 provider:
   name: aws
   runtime: nodejs12.x
+  region: eu-west-1
 
 plugins:
   - serverless-finch


### PR DESCRIPTION
Unfortunately I've added most of the commits directly in main branch, because I didn't know about PR practice with tasks.

But you can check my work by direct commits in main branch. Sorry, next time everything will be in PR

This is link to my automated deployed app with cloudformation: https://d379tfwbxbtrny.cloudfront.net/
This is direct link, which should be forbidden: http://sport-nutrition2-app.s3-website-us-east-1.amazonaws.com/

And also I've deleted cloudfront and bucket, which I've created by hands. Because I've followed the video, but in chat people said, that you shouldn't delete it.